### PR TITLE
support \(...\) and \[...\] style math formula

### DIFF
--- a/app/components/markdown.tsx
+++ b/app/components/markdown.tsx
@@ -116,9 +116,26 @@ function escapeDollarNumber(text: string) {
   return escapedText;
 }
 
+function escapeBrackets(text: string) {
+  const pattern = /(```[\s\S]+?```)|\\\[(.*?[^\\])\\\]|\\\((.+?)\\\)/g;
+  return text.replace(
+    pattern,
+    (match, codeBlock, squareBracket, roundBracket) => {
+      if (codeBlock) {
+        return codeBlock;
+      } else if (squareBracket) {
+        return `$$${squareBracket}$$`;
+      } else if (roundBracket) {
+        return `$${roundBracket}$`;
+      }
+      return match;
+    },
+  );
+}
+
 function _MarkDownContent(props: { content: string }) {
   const escapedContent = useMemo(
-    () => escapeDollarNumber(props.content),
+    () => escapeBrackets(escapeDollarNumber(props.content)),
     [props.content],
   );
 


### PR DESCRIPTION
解决gpt回复的公式使用 \(...\) 和 \[...\] 格式导致的渲染问题  https://github.com/ChatGPTNextWeb/ChatGPT-Next-Web/issues/3436#issuecomment-1842626873

remark-math 里有人讨论了这个问题，不过结论是不会支持这种格式 https://github.com/remarkjs/remark-math/issues/39

最后参考了这里的实现，不会修改代码块(即\```...\```中的文本)中的文本：
https://github.com/danny-avila/LibreChat/pull/1585
https://github.com/danny-avila/LibreChat/pull/1585/files#diff-9850a69e517911cf0cdab10bb95d007c71d78758bfd1cc0bb76ccc30a533811c